### PR TITLE
Remove say command from git-secrets

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -205,7 +205,8 @@ install_hook() {
   echo "#!/usr/bin/env bash" > "${dest}"
   echo "git secrets --${cmd} -- \"\$@\"" >> "${dest}"
   chmod +x "${dest}"
-  say "$(tput setaf 2)✓$(tput sgr 0) Installed ${hook} hook to ${dest}"
+  [ -t 1 ] && which tput >/dev/null && echo -n "$(tput setaf 2)✓$(tput sgr 0) "
+  echo "Installed ${hook} hook to ${dest}"
 }
 
 install_all_hooks() {


### PR DESCRIPTION
It looks like git removed the say command in [this commit](https://github.com/git/git/commit/5b893f7d81eb7feb43662ed8663e2af76a76b4c8). git-secrets relies on this, and hasn't patched it. So, here we are.
